### PR TITLE
重写 http 处理

### DIFF
--- a/src/smart_qq_bot/bot.py
+++ b/src/smart_qq_bot/bot.py
@@ -412,6 +412,7 @@ class QQBot(object):
                     data={'bkn': self.bkn},
                     refer='http://qun.qq.com/member.html',
                     parser=htmlencoded_json_parser,
+                    status_key='ec',
                 )
             qq_list = []
             for member_list in friend_groups.values():

--- a/src/smart_qq_bot/http_client.py
+++ b/src/smart_qq_bot/http_client.py
@@ -102,17 +102,15 @@ class HttpClient(object):
             logger.error("request failed, retrying in 2 seconds")
             time.sleep(2)
 
-    def load_result(self, url, *args, **kwargs):
+    def load_result(self, url, data=None, status_key='retcode', *args, **kwargs):
         validator = kwargs["validator"] if "validator" in kwargs else None
         def result_validator(response):
-            assert 'retcode' in response and response['retcode'] == 0 \
-                or 'errCode' in response and response['errCode'] == 0 \
-                or 'ec' in response and response['ec'] == 0, repr(response)
+            assert status_key in response and response[status_key] == 0, 'invalid status: {}'.format(repr(response))
             assert 'result' in response, repr(response)
             if validator:
                 validator(response['result'])
         kwargs["validator"] = result_validator
-        response = self.load(url, *args, **kwargs)
+        response = self.load(url, data=data, *args, **kwargs)
         return response['result']
 
     def get_cookie(self, key):


### PR DESCRIPTION
抱着以下想法修改的

 * 把所有 http 请求/retry/json 等处理都纳入 load 函数统一处理
 * post/get 统一 load, 用是否有 data 来区别 (两个函数实在没什么差别)
 * 常用的 response['result'] 纳入 load_result 函数处理
 * raise+return false+if 的处理统一成 raise (主要是 login 部分, 原来的流程可能有流程逻辑遗漏)
 * 修正部分返回结果的 key (errCode 之类)
 * 修正部分 retry 错误, 反复 json decode 无意义
 * 顺手改了一些延迟微调, 每秒检查是否扫码没必要 改成官网的大约2秒
 * bot/plugin 请求获取更多资料的 api, 抛出异常可有效避免继续执行代码
未考虑处理部分:
 * 如果当前登录超时/被踢, 是否需要在每个请求里都做判断处理, 等 poll 返回错误就够了?
 * 缓存结果
 * login 成功后获取资料如果抛出异常, 尚未考虑处理 (需要设计重新登录流程)
 * 除了 poll 之外其他还有接口函数可能返回空值并未完全梳理

改进采用 parser/validator 概念. raise都能引发 retry
对于 login 的有效错误放在load外面处理, 不做retry

可能未完成, 不合适 merge. 预先创建 PR 是为了抛砖引玉 希望多讨论下