### PR TITLE
Update: 为插件Satoru增加正则匹配功能，学习时可使用正则表达式

### DIFF
--- a/src/smart_qq_plugins/satoru.py
+++ b/src/smart_qq_plugins/satoru.py
@@ -50,7 +50,13 @@ class Satoru(object):
         logger.info("key [%s] removed" % key)
 
     def match(self, key):
-        if key in self.data:
+        keylist = []
+        for keyword in self.data:
+            match = re.compile(keyword).search(key)
+            if match:
+                keylist.append(keyword)
+        if len(keylist):
+            key = random.choice(keylist)
             result = self.data[key]
             return result[randint(0, len(result) - 1)]
         return None


### PR DESCRIPTION
使用Satoru插件时，目前的学习只能实现关键词的精确匹配。
增加正则查询之后，能更加有效进行关键词匹配。

例：
发送：
学习{哪里.*买.*(肉|水果|蔬菜)}{购买食品可以到超市A。}
发送：
请问在哪里可以买到羊肉？
回复：
购买食品可以到超市A。
